### PR TITLE
After a rebalance set consumedOffset=commitedOffset and NOT consumedOffset=fetchOffset which could lead to data loss. Don't commit offset if it already commited

### DIFF
--- a/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
+++ b/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
@@ -154,16 +154,21 @@ namespace Kafka.Client.Consumers
                             {
                                 // Save offsets unconditionally. Kafka's latestOffset for a particular topic-partition can go backward
                                 // if a follwer which is not fully caught up becomes a leader. We still need to save the conumed offsets even then.
-                                try
+                                //skip only if we are trying to commit the same offset
+
+                                if (newOffset != partition.Value.CommitedOffset)
                                 {
-                                    ZkUtils.UpdatePersistentPath(GetZkClient(),
-                                                                    topicDirs.ConsumerOffsetDir + "/" +
-                                                                    partition.Value.PartitionId, newOffset.ToString());
-                                    partition.Value.CommitedOffset = newOffset;
-                                }
-                                catch (Exception ex)
-                                {
-                                    Logger.ErrorFormat("error in CommitOffsets UpdatePersistentPath : {0}", ex.FormatException());
+                                    try
+                                    {
+                                        ZkUtils.UpdatePersistentPath(GetZkClient(),
+                                                                        topicDirs.ConsumerOffsetDir + "/" +
+                                                                        partition.Value.PartitionId, newOffset.ToString());
+                                        partition.Value.CommitedOffset = newOffset;
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Logger.ErrorFormat("error in CommitOffsets UpdatePersistentPath : {0}", ex.FormatException());
+                                    }
                                 }
                             }
                             else

--- a/src/KafkaNET.Library/ZooKeeperIntegration/Listeners/ZKRebalancerListener.cs
+++ b/src/KafkaNET.Library/ZooKeeperIntegration/Listeners/ZKRebalancerListener.cs
@@ -530,7 +530,7 @@ namespace Kafka.Client.ZooKeeperIntegration.Listeners
                 leader,
                 partitionId,
                 queue,
-                offset,
+                offsetCommited,
                 offset,
                 offset,
                 this.config.FetchSize,


### PR DESCRIPTION
	modified:   src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
	modified:   src/KafkaNET.Library/ZooKeeperIntegration/Listeners/ZKRebalancerListener.cs