### PR TITLE
[PVS-Studio] ConsumeGroupFindNewLeaderSleepIntervalMs initialization

### DIFF
--- a/src/KafkaNET.Library/Cfg/ConsumerConfiguration.cs
+++ b/src/KafkaNET.Library/Cfg/ConsumerConfiguration.cs
@@ -124,7 +124,7 @@ namespace Kafka.Client.Cfg
             this.ShutdownTimeout = config.ShutdownTimeout;
             this.MaxFetchBufferLength = config.MaxFetchBufferLength;
             this.ConsumeGroupRebalanceRetryIntervalMs = DefaultConsumeGroupRebalanceRetryIntervalMs;
-            this.ConsumeGroupFindNewLeaderSleepIntervalMs = ConsumeGroupFindNewLeaderSleepIntervalMs;
+            this.ConsumeGroupFindNewLeaderSleepIntervalMs = DefaultConsumeGroupFindNewLeaderSleepIntervalMs;
             if (config.Broker.ElementInformation.IsPresent)
             {
                 this.SetBrokerConfiguration(config.Broker);


### PR DESCRIPTION
The kind people at Viva64 gave an evaluation license for PVS-Studio to try out on some OSS projects, and running it on Kafkanet source code found this problem.
http://www.viva64.com/en/pvs-studio/

Error V3005. The 'ConsumeGroupFindNewLeaderSleepIntervalMs' variable is assigned to itself
http://www.viva64.com/en/d/0403/print/

Fixes issue #20