### PR TITLE
Kafka 0.9 producer fix

### DIFF
--- a/src/KafkaNET.Library/Cfg/SyncProducerConfiguration.cs
+++ b/src/KafkaNET.Library/Cfg/SyncProducerConfiguration.cs
@@ -35,7 +35,7 @@ namespace Kafka.Client.Cfg
 
         public const int DefaultCorrelationId = -1;
 
-        public const string DefaultClientId = "";
+        public const string DefaultClientId = " ";
 
         public const short DefaultRequiredAcks = 0;
 

--- a/src/KafkaNET.Library/Cfg/SyncProducerConfiguration.cs
+++ b/src/KafkaNET.Library/Cfg/SyncProducerConfiguration.cs
@@ -35,7 +35,7 @@ namespace Kafka.Client.Cfg
 
         public const int DefaultCorrelationId = -1;
 
-        public const string DefaultClientId = " ";
+        public const string DefaultClientId = " "; //NOTE: Space is required for 0.9 producer https://issues.apache.org/jira/browse/KAFKA-3088
 
         public const short DefaultRequiredAcks = 0;
 


### PR DESCRIPTION
Adding a space for DefaultClientId was required for kafkanet to work with Kafka 0.9.  https://issues.apache.org/jira/browse/KAFKA-3088

With this fix: able to successfully produce messages from kafkanet to 0.9 and used the 0.9 Java consumer to consume them.