### PR TITLE
override setting position of fetch offset with flag

### DIFF
--- a/src/KafkaNET.Library/Consumers/IConsumerConnector.cs
+++ b/src/KafkaNET.Library/Consumers/IConsumerConnector.cs
@@ -57,7 +57,8 @@ namespace Kafka.Client.Consumers
         /// <param name="topic">The topic </param>
         /// <param name="partition">The partition</param>
         /// <param name="offset">The offset</param>
-        void CommitOffset(string topic, int partition, long offset);
+        /// <param name="setPosition">Indicates whether to set the fetcher's offset to the value committed. Default = true.</param>
+        void CommitOffset(string topic, int partition, long offset, bool setPosition = true);
 
         /// <summary>
         /// Return offsets of current ConsumerGroup

--- a/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
+++ b/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
@@ -215,7 +215,8 @@ namespace Kafka.Client.Consumers
         /// <param name="topic"></param>
         /// <param name="partition"></param>
         /// <param name="offset"></param>
-        public void CommitOffset(string topic, int partition, long offset)
+        /// <param name="setPosition">Indicates whether to set the fetcher's offset to the value committed. Default = true.</param>
+        public void CommitOffset(string topic, int partition, long offset, bool setPosition = true)
         {
             this.EnsuresNotDisposed();
             if (this.GetZkClient() == null)
@@ -241,8 +242,11 @@ namespace Kafka.Client.Consumers
                             topicDirs.ConsumerOffsetDir + "/" +
                             partitionTopicInfo.PartitionId, offset.ToString());
                         partitionTopicInfo.CommitedOffset = offset;
-                        partitionTopicInfo.ConsumeOffset = offset;
-                        partitionTopicInfo.FetchOffset = offset;
+                        if (setPosition)
+                        {
+                            partitionTopicInfo.ConsumeOffset = offset;
+                            partitionTopicInfo.FetchOffset = offset;
+                        }
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
fixes #23 by adding a flag for setting the position of the fetcher on `partitionTopicInfo`. This is `false` by default and when set to `true` will avoid setting the `ConsumeOffset` and `FetchOffset` values, so the consumer will continue on its merry way.