### PR TITLE
Gfodor/add throttle time to fetch response

### DIFF
--- a/src/Kafka.Client.Tests/Response/FetchResponseTest.cs
+++ b/src/Kafka.Client.Tests/Response/FetchResponseTest.cs
@@ -19,32 +19,58 @@ namespace Kafka.Client.Tests.Response
     {
         [TestMethod]
         [TestCategory(TestCategories.BVT)]
-        public void ShouldAbleToParseFetchResponse()
+        public void ShouldAbleToParseV0FetchResponse()
         {
             var stream = new MemoryStream();
-            var writer = new KafkaBinaryWriter(stream);
-            writer.Write(1);
-            writer.Write(123); // correlation id
-            writer.Write(1); // data count
-            writer.WriteShortString("topic1");
-            writer.Write(1); // partition count
-            writer.Write(111); //partition id
-            writer.Write((short)ErrorMapping.NoError);
-
-            writer.Write(1011L); // hw            
-            var messageStream = new MemoryStream();
-            var messageWriter = new KafkaBinaryWriter(messageStream);
-            new BufferedMessageSet(new List<Message>() { new Message(new byte[100]) }, 0).WriteTo(messageWriter);
-            writer.Write((int)messageStream.Length);
-            writer.Write(messageStream.GetBuffer(), 0, (int)messageStream.Length);
-            stream.Seek(0, SeekOrigin.Begin);
+            WriteTestFetchResponse(stream, 0);
             var reader = new KafkaBinaryReader(stream);
             var response = new FetchResponse.Parser(0).ParseFrom(reader);
+            response.ThrottleTime.ShouldBeEquivalentTo(0);
             var set = response.MessageSet("topic1", 111);
             set.Should().NotBeNull();
             var messages = set.Messages.ToList();
             messages.Count().Should().Be(1);
             messages.First().Payload.Length.Should().Be(100);
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategories.BVT)]
+        public void ShouldAbleToParseV1FetchResponse()
+        {
+            var stream = new MemoryStream();
+            WriteTestFetchResponse(stream, 1);
+            var reader = new KafkaBinaryReader(stream);
+            var response = new FetchResponse.Parser(1).ParseFrom(reader);
+            response.ThrottleTime.ShouldBeEquivalentTo(456);
+            var set = response.MessageSet("topic1", 111);
+            set.Should().NotBeNull();
+            var messages = set.Messages.ToList();
+            messages.Count().Should().Be(1);
+            messages.First().Payload.Length.Should().Be(100);
+        }
+
+        private static void WriteTestFetchResponse(MemoryStream stream, int versionId)
+        {
+            var writer = new KafkaBinaryWriter(stream);
+            writer.Write(1);
+            writer.Write(123); // correlation id
+            if (versionId > 0)
+            {
+               writer.Write(456); 
+            }
+            writer.Write(1); // data count
+            writer.WriteShortString("topic1");
+            writer.Write(1); // partition count
+            writer.Write(111); //partition id
+            writer.Write((short) ErrorMapping.NoError);
+
+            writer.Write(1011L); // hw            
+            var messageStream = new MemoryStream();
+            var messageWriter = new KafkaBinaryWriter(messageStream);
+            new BufferedMessageSet(new List<Message>() {new Message(new byte[100])}, 0).WriteTo(messageWriter);
+            writer.Write((int) messageStream.Length);
+            writer.Write(messageStream.GetBuffer(), 0, (int) messageStream.Length);
+            stream.Seek(0, SeekOrigin.Begin);
         }
     }
 }

--- a/src/Kafka.Client.Tests/Response/FetchResponseTest.cs
+++ b/src/Kafka.Client.Tests/Response/FetchResponseTest.cs
@@ -39,7 +39,7 @@ namespace Kafka.Client.Tests.Response
             writer.Write(messageStream.GetBuffer(), 0, (int)messageStream.Length);
             stream.Seek(0, SeekOrigin.Begin);
             var reader = new KafkaBinaryReader(stream);
-            var response = new FetchResponse.Parser().ParseFrom(reader);
+            var response = new FetchResponse.Parser(0).ParseFrom(reader);
             var set = response.MessageSet("topic1", 111);
             set.Should().NotBeNull();
             var messages = set.Messages.ToList();

--- a/src/KafkaNET.Library/KafkaConnection.cs
+++ b/src/KafkaNET.Library/KafkaConnection.cs
@@ -139,7 +139,7 @@ namespace Kafka.Client
         {
             this.EnsuresNotDisposed();
             Guard.NotNull(request, "request");
-            return this.Handle(request.RequestBuffer.GetBuffer(), new FetchResponse.Parser());
+            return this.Handle(request.RequestBuffer.GetBuffer(), new FetchResponse.Parser(request.VersionId));
         }
 
         /// <summary>

--- a/src/KafkaNET.Library/Responses/FetchResponse.cs
+++ b/src/KafkaNET.Library/Responses/FetchResponse.cs
@@ -39,17 +39,19 @@ namespace Kafka.Client.Responses
             this.TopicDataDict = data.GroupBy(x => x.Topic, x => x)
                .ToDictionary(x => x.Key, x => x.ToList().FirstOrDefault());
         }
-        public FetchResponse(int correlationId, IEnumerable<TopicData> data, int size)
+        public FetchResponse(int correlationId, IEnumerable<TopicData> data, int size, int throttleTime)
         {
             Guard.NotNull(data, "data");
             this.CorrelationId = correlationId;
             this.TopicDataDict = data.GroupBy(x => x.Topic, x => x)
                .ToDictionary(x => x.Key, x => x.ToList().FirstOrDefault());
             this.Size = size;
+            this.ThrottleTime = throttleTime;
         }
 
         public int Size { get; private set; }
         public int CorrelationId { get; private set; }
+        public int ThrottleTime { get; private set; }
         public Dictionary<string, TopicData> TopicDataDict { get; private set; }
 
         public BufferedMessageSet MessageSet(string topic, int partition)
@@ -92,13 +94,22 @@ namespace Kafka.Client.Responses
 
         public class Parser : IResponseParser<FetchResponse>
         {
+            private int versionId;
+
+            public Parser(int versionId)
+            {
+                this.versionId = versionId;
+            }
+
             public FetchResponse ParseFrom(KafkaBinaryReader reader)
             {
-                int size = 0, correlationId = 0, dataCount = 0;
+                int size = 0, correlationId = 0, dataCount = 0, throttleTime = 0;
                 try
                 {
                     size = reader.ReadInt32();
                     correlationId = reader.ReadInt32();
+                    if (versionId > 0)
+                        throttleTime = reader.ReadInt32();
                     dataCount = reader.ReadInt32();
                     var data = new TopicData[dataCount];
                     for (int i = 0; i < dataCount; i++)
@@ -106,7 +117,7 @@ namespace Kafka.Client.Responses
                         data[i] = TopicData.ParseFrom(reader);
                     }
 
-                    return new FetchResponse(correlationId, data, size);
+                    return new FetchResponse(correlationId, data, size, throttleTime);
                 }
                 catch (OutOfMemoryException mex)
                 {

--- a/src/KafkaNET.Library/Responses/FetchResponse.cs
+++ b/src/KafkaNET.Library/Responses/FetchResponse.cs
@@ -39,14 +39,14 @@ namespace Kafka.Client.Responses
             this.TopicDataDict = data.GroupBy(x => x.Topic, x => x)
                .ToDictionary(x => x.Key, x => x.ToList().FirstOrDefault());
         }
-        public FetchResponse(int correlationId, IEnumerable<TopicData> data, int size, int throttleTime)
+        public FetchResponse(int correlationId, int throttleTime, IEnumerable<TopicData> data, int size)
         {
             Guard.NotNull(data, "data");
             this.CorrelationId = correlationId;
+            this.ThrottleTime = throttleTime;
             this.TopicDataDict = data.GroupBy(x => x.Topic, x => x)
                .ToDictionary(x => x.Key, x => x.ToList().FirstOrDefault());
             this.Size = size;
-            this.ThrottleTime = throttleTime;
         }
 
         public int Size { get; private set; }
@@ -117,7 +117,7 @@ namespace Kafka.Client.Responses
                         data[i] = TopicData.ParseFrom(reader);
                     }
 
-                    return new FetchResponse(correlationId, data, size, throttleTime);
+                    return new FetchResponse(correlationId, throttleTime, data, size);
                 }
                 catch (OutOfMemoryException mex)
                 {


### PR DESCRIPTION
The Kafka protocol specifies that the v1 format of FetchResponse (introduced in 0.9.0) includes a throttle time field that precedes the message set. The current client seems to break against 0.9.0 if this field is not read properly. This patch extends the FetchResponse.Parser to be parameterized against the version of the protocol it needs to read, and then reads this field properly if the original request was in version 1 or higher.

(Note that the protocol documentation found [here](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol) has a bug and mis-states the throttle time follows the message set -- it actually appears before the message set. The [primary protocol docs](http://kafka.apache.org/protocol.html#protocol_details) properly describes the response.)