### PR TITLE
Add IZookeeperConsumerConnector interface

### DIFF
--- a/src/KafkaNET.Library/Consumers/IKafkaMessageStream.cs
+++ b/src/KafkaNET.Library/Consumers/IKafkaMessageStream.cs
@@ -24,7 +24,7 @@ namespace Kafka.Client.Consumers
     {
         IConsumerIterator<TData> iterator { get; }
         int Count { get; }
-        IEnumerable<TData> GetCancellable(CancellationToken cancellationToken);
+        IKafkaMessageStream<TData> GetCancellable(CancellationToken cancellationToken);
         void Clear();
     }
 }

--- a/src/KafkaNET.Library/Consumers/IZookeeperConsumerConnector.cs
+++ b/src/KafkaNET.Library/Consumers/IZookeeperConsumerConnector.cs
@@ -17,6 +17,7 @@
 
 namespace Kafka.Client.Consumers
 {
+    using Kafka.Client.Serialization;
     using System.Collections.Generic;
 
     public interface IZookeeperConsumerConnector : IConsumerConnector
@@ -26,6 +27,8 @@ namespace Kafka.Client.Consumers
         void AutoCommit();
 
         string GetConsumerIdString();
+
+        IDictionary<string, IList<IKafkaMessageStream<TData>>> CreateMessageStreams<TData>(IDictionary<string, int> topicCountDict, IDecoder<TData> decoder);
 
         IDictionary<string, IDictionary<int, PartitionTopicInfo>> GetCurrentOwnership();
 

--- a/src/KafkaNET.Library/Consumers/IZookeeperConsumerConnector.cs
+++ b/src/KafkaNET.Library/Consumers/IZookeeperConsumerConnector.cs
@@ -1,0 +1,34 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Kafka.Client.Consumers
+{
+    using System.Collections.Generic;
+
+    public interface IZookeeperConsumerConnector : IConsumerConnector
+    {
+        string ConsumerGroup { get; }
+
+        void AutoCommit();
+
+        string GetConsumerIdString();
+
+        IDictionary<string, IDictionary<int, PartitionTopicInfo>> GetCurrentOwnership();
+
+        void ReleaseAllPartitionOwnerships();
+    }
+}

--- a/src/KafkaNET.Library/Consumers/KafkaMessageStream.cs
+++ b/src/KafkaNET.Library/Consumers/KafkaMessageStream.cs
@@ -57,7 +57,7 @@ namespace Kafka.Client.Consumers
             this.iterator = new ConsumerIterator<TData>(topic, queue, consumerTimeoutMs, decoder, token);
         }
 
-        public IEnumerable<TData> GetCancellable(CancellationToken cancellationToken)
+        public IKafkaMessageStream<TData> GetCancellable(CancellationToken cancellationToken)
         {
             return new KafkaMessageStream<TData>(this.topic, this.queue, this.consumerTimeoutMs, this.decoder, cancellationToken);
         }

--- a/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
+++ b/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
@@ -36,7 +36,7 @@ namespace Kafka.Client.Consumers
     /// The consumer high-level API, that hides the details of brokers from the consumer. 
     /// It also maintains the state of what has been consumed. 
     /// </summary>
-    public class ZookeeperConsumerConnector : KafkaClientBase, IConsumerConnector
+    public class ZookeeperConsumerConnector : KafkaClientBase, IZookeeperConsumerConnector
     {
         public static log4net.ILog Logger = log4net.LogManager.GetLogger(typeof(ZookeeperConsumerConnector));
         public static readonly int MaxNRetries = 4;

--- a/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
+++ b/src/KafkaNET.Library/Consumers/ZookeeperConsumerConnector.cs
@@ -18,19 +18,14 @@
 namespace Kafka.Client.Consumers
 {
     using Kafka.Client.Cfg;
-    using Kafka.Client.Cluster;
     using Kafka.Client.Serialization;
     using Kafka.Client.Utils;
     using Kafka.Client.ZooKeeperIntegration;
     using Kafka.Client.ZooKeeperIntegration.Listeners;
-    using log4net;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.Net;
-    using System.Reflection;
+    using System.Linq;
 
     /// <summary>
     /// The consumer high-level API, that hides the details of brokers from the consumer. 
@@ -333,6 +328,15 @@ namespace Kafka.Client.Consumers
         {
             this.EnsuresNotDisposed();
             return this.Consume(topicCountDict, decoder);
+        }
+
+        IDictionary<string, IList<IKafkaMessageStream<TData>>> IZookeeperConsumerConnector.CreateMessageStreams<TData>(IDictionary<string, int> topicCountDict, IDecoder<TData> decoder)
+        {
+            return CreateMessageStreams(topicCountDict, decoder)
+                .ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => (IList<IKafkaMessageStream<TData>>)kvp.Value.Cast<IKafkaMessageStream<TData>>().ToList()
+                );
         }
 
         public Dictionary<int, long> GetOffset(string topic)

--- a/src/KafkaNET.Library/KafkaNET.Library.csproj
+++ b/src/KafkaNET.Library/KafkaNET.Library.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Cfg\ProducerConfiguration.cs" />
     <Compile Include="Consumers\IConsumerIterator.cs" />
     <Compile Include="Consumers\IKafkaMessageStream.cs" />
+    <Compile Include="Consumers\IZookeeperConsumerConnector.cs" />
     <Compile Include="ZooKeeperIntegration\Events\ChildChangedEventItem.cs" />
     <Compile Include="ZooKeeperIntegration\Events\DataChangedEventItem.cs" />
     <Compile Include="ZooKeeperIntegration\Events\ZooKeeperChildChangedEventArgs.cs" />


### PR DESCRIPTION
Allow consuming libraries to mock interactions with ZookeeperConsumerConnector by adding an interface.