### PR TITLE
Fix new consumer group blocking

### DIFF
--- a/src/KafkaNET.Library/ZooKeeperIntegration/Listeners/ZKRebalancerListener.cs
+++ b/src/KafkaNET.Library/ZooKeeperIntegration/Listeners/ZKRebalancerListener.cs
@@ -514,6 +514,7 @@ namespace Kafka.Client.ZooKeeperIntegration.Listeners
                     default:
                         throw new ConfigurationErrorsException("Wrong value in autoOffsetReset in ConsumerConfig");
                 }
+                offsetCommited = Math.Max(offset - 1, 0);
             }
             else
             {


### PR DESCRIPTION
Fixes #39 by setting the committedOffset to start/end - 1 when a consumer group starts consuming a topic.