### PR TITLE
Fix nuget package creation of KafkaNET.library

### DIFF
--- a/src/KafkaNET.Library/KafkaNET.Library.nuspec
+++ b/src/KafkaNET.Library/KafkaNET.Library.nuspec
@@ -18,8 +18,5 @@
 	</dependencies>
   </metadata>
   <files>
-		<file src="bin\Release\KafkaNET.Library.dll" target="lib\net45" />
-		<file src="bin\Release\KafkaNET.Library.pdb" target="lib\net45" />
-		<file src="**\*.cs" target="src" />
   </files>
 </package>


### PR DESCRIPTION
This change corrects the nuspec definition for the kafkanet.library project, enabling the nupkg to be created at build time.